### PR TITLE
Fix project name typo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@
 cmake_minimum_required(VERSION 3.16.0)
 
 # Define the project
-project(quaint VERSION 1.0.0)
+project(test-console VERSION 1.0.0)
 
 # Use C++17
 set(CMAKE_CXX_STANDARD 17)

--- a/platform/windows-console.cpp
+++ b/platform/windows-console.cpp
@@ -25,6 +25,13 @@
  * SOFTWARE.
  */
 
+/*
+ * This version of the getUserInput() is and related
+ * functions is based on:
+ *   https://docs.microsoft.com/en-us/windows/console/reading-input-buffer-events
+ *
+ */
+
 // test-console includes
 #include <console.h>
 

--- a/platform/windows-console.cpp
+++ b/platform/windows-console.cpp
@@ -26,8 +26,8 @@
  */
 
 /*
- * This version of the getUserInput() is and related
- * functions is based on:
+ * This version of the getUserInput() and related
+ * functions are based on:
  *   https://docs.microsoft.com/en-us/windows/console/reading-input-buffer-events
  *
  */


### PR DESCRIPTION
There was a copy and paste error in the main CMake file where the project name was incorrect.

Changed to test-console.