### PR TITLE
Add left and right arrow movement to insert characters

### DIFF
--- a/console.h
+++ b/console.h
@@ -32,6 +32,7 @@
 #include <string>
 #include <tuple>
 #include <vector>
+#include <map>
 
 //! Indicate the type of key press
 enum class KeyPressed
@@ -39,6 +40,9 @@ enum class KeyPressed
   alphanum,    /*!< A printable character was typed */
   enter,       /*!< Enter (or related key) was pressed */
   backspace,   /*!< Backspace was pressed */
+  del,         /*!< The Delete (or Del) key was pressed */
+  leftarrow,   /*!< The left arrow key was pressed */
+  rightarrow,  /*!< The right arrow key was pressed */
   undefined,   /*!< The key press was not something we handle */
   error        /*!< If there is a problem with the key reader */
 };
@@ -90,4 +94,7 @@ private:
 
   //! Variables needed by the platform specific code
   PlatformVariables platform_vars_;
+
+  //! The key mapping to help with key inputs
+  std::map<KeyMapping, KeyPressed> key_map_;
 };

--- a/platform/linux-console.h
+++ b/platform/linux-console.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include <termios.h>
+#include <string>
 
 //! Define a struct to hold variables needed by the windows console
 struct PlatformVariables
@@ -35,3 +36,6 @@ struct PlatformVariables
   //! Save the original console mode
   struct termios old_state;
 };
+
+//! A key mapping type
+using KeyMapping = std::string;

--- a/platform/windows-console.h
+++ b/platform/windows-console.h
@@ -42,3 +42,6 @@ struct PlatformVariables
   //! Buffer size for input events
   static const unsigned int input_buffer_size = 128;
 };
+
+//! Key mappings type
+using KeyMapping = WORD;


### PR DESCRIPTION
Updated the Windows and Linux versions to allow moving around the command line with the left and right arrows.

It also allows the insertion of new character in the middle of a line, and the deletion of a character from the middle of a line with either `<Backspace>` or `<Delete>`.