### PR TITLE
Allow up and down arrows to select history

### DIFF
--- a/console.cpp
+++ b/console.cpp
@@ -55,7 +55,16 @@ int TestConsole::start()
       // Flush to make sure the prompt is shown
       std::cout << prompt_ << " " << std::flush;
       input = getUserInputLine();
-      std::cout << "You typed: " << input << "\r\n";
+
+      // Not a fully featured history, but
+      // we can show what's in the list
+      if (input == "history")
+      {
+        for (auto h : history_)
+          std::cout << h << "\r\n";
+      }
+      else
+        std::cout << "You typed: " << input << "\r\n";
 
       // Save the history if it's not the same as the previous entry
       if (history_.empty() || input != history_.back())

--- a/console.h
+++ b/console.h
@@ -41,8 +41,11 @@ enum class KeyPressed
   enter,       /*!< Enter (or related key) was pressed */
   backspace,   /*!< Backspace was pressed */
   del,         /*!< The Delete (or Del) key was pressed */
+  tab,         /*!< The Tab key was pressed */
   leftarrow,   /*!< The left arrow key was pressed */
   rightarrow,  /*!< The right arrow key was pressed */
+  uparrow,     /*!< The up arrow key was pressed */
+  downarrow,   /*!< The down arrow key was pressed */
   undefined,   /*!< The key press was not something we handle */
   error        /*!< If there is a problem with the key reader */
 };
@@ -73,16 +76,24 @@ private:
    */
   void initialisePlatformVariables();
 
-  /* Get the next line of input from the user
+  /*! Get the next line of input from the user
    * \return The line entered by the user at the command line
    */
-  std::string getUserInputLine();
+  std::string getUserInputLine() const;
+
+  /*! Show a new line on the display
+   * \param old_line_size The length of the line we're replacing
+   * \param new_line The line to replace the existing line
+   * \param cur_pos The current position of the cursor in the line
+   */
+  void replaceLine(const std::string::size_type& old_line, const std::string& new_line,
+    const std::string::size_type& cur_pos) const;
 
   /*! Get the next keypress
    * \returns A vector containing the key types and a char. If the key isn't alphanumeric, the char will be '\0'
    * \note This is implemented specific to the platform
    */
-  std::vector<std::tuple<KeyPressed, char>> getKeyPresses();
+  std::vector<std::tuple<KeyPressed, char>> getKeyPresses() const;
 
   /*! Clean up the platform specific console
    * \note This is implemented specific to the platform
@@ -97,4 +108,7 @@ private:
 
   //! The key mapping to help with key inputs
   std::map<KeyMapping, KeyPressed> key_map_;
+
+  //! The history
+  std::vector<std::string> history_;
 };

--- a/platform/linux-console.cpp
+++ b/platform/linux-console.cpp
@@ -82,6 +82,9 @@ namespace
     if (km != key_map.end())
       return std::make_tuple(km->second, '\0');
 
+    for (auto c : input)
+      std::cout << "Next char: " << c << ", value: " << (int)c << "\r\n";
+
     // Return that we don't know the code
     return std::make_tuple(KeyPressed::undefined, '\0');
   }
@@ -122,20 +125,23 @@ void TestConsole::initialisePlatformVariables()
     throw std::runtime_error("Unable to set new console state with tcsetattr()");
 
   // Set up the key mappings
+  const std::string tab(1, 9);
   const std::string ret(1, 13);
-  const std::string bsp(1, 127);
   const std::string esc(1, 27);
-
+  const std::string bsp(1, 127);
+  
+  key_map_[tab] = KeyPressed::tab;
   key_map_[ret] = KeyPressed::enter;
-  key_map_[bsp] = KeyPressed::backspace;
-  key_map_[esc + "[D"] = KeyPressed::leftarrow;
-  key_map_[esc + "[C"] = KeyPressed::rightarrow;
   key_map_[esc + "[3~"] = KeyPressed::del;
-
+  key_map_[esc + "[A"] = KeyPressed::uparrow;
+  key_map_[esc + "[B"] = KeyPressed::downarrow;
+  key_map_[esc + "[C"] = KeyPressed::rightarrow;
+  key_map_[esc + "[D"] = KeyPressed::leftarrow;
+  key_map_[bsp] = KeyPressed::backspace;
 }
 
 // This has the linux specific code
-std::vector<std::tuple<KeyPressed, char>> TestConsole::getKeyPresses()
+std::vector<std::tuple<KeyPressed, char>> TestConsole::getKeyPresses() const
 {
   // The return value
   std::vector<std::tuple<KeyPressed, char>> ret;

--- a/platform/windows-console.cpp
+++ b/platform/windows-console.cpp
@@ -96,14 +96,17 @@ void TestConsole::initialisePlatformVariables()
 
   // Initialise the key mapping
   key_map_[8] = KeyPressed::backspace;
+  key_map_[9] = KeyPressed::tab;
   key_map_[13] = KeyPressed::enter;
   key_map_[37] = KeyPressed::leftarrow;
+  key_map_[38] = KeyPressed::uparrow;
   key_map_[39] = KeyPressed::rightarrow;
+  key_map_[40] = KeyPressed::downarrow;
   key_map_[46] = KeyPressed::del;
 }
 
 // This handles the windows specific code
-std::vector<std::tuple<KeyPressed, char>> TestConsole::getKeyPresses()
+std::vector<std::tuple<KeyPressed, char>> TestConsole::getKeyPresses() const
 {
   // The return value
   std::vector<std::tuple<KeyPressed, char>> ret;


### PR DESCRIPTION
Added a history feature using up and down arrows.

Also added a `history` command to show what's in the history list - it's not a fully-featured history, but just shows the list.

Closes #8 